### PR TITLE
Implement engine engine serialize

### DIFF
--- a/tensorrt-sys/Cargo.toml
+++ b/tensorrt-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorrt-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Mason Stallmo <masonstallmo@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/tensorrt-sys/src/bindings.rs
+++ b/tensorrt-sys/src/bindings.rs
@@ -167,7 +167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn engine_seralize(engine: *mut Engine_t) -> *mut HostMemory_t;
+    pub fn engine_serialize(engine: *mut Engine_t) -> *mut HostMemory_t;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/tensorrt-sys/src/bindings.rs
+++ b/tensorrt-sys/src/bindings.rs
@@ -123,6 +123,21 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct HostMemory {
+    _unused: [u8; 0],
+}
+pub type HostMemory_t = HostMemory;
+extern "C" {
+    pub fn create_host_memory(host_memory: *mut ::std::os::raw::c_void) -> *mut HostMemory_t;
+}
+extern "C" {
+    pub fn host_memory_get_data(host_memory: *mut HostMemory_t) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn host_memory_get_size(host_memory: *mut HostMemory_t) -> usize;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Engine {
     _unused: [u8; 0],
 }
@@ -150,6 +165,9 @@ extern "C" {
         engine: *mut Engine_t,
         op_name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn engine_seralize(engine: *mut Engine_t) -> *mut HostMemory_t;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -276,7 +294,7 @@ extern "C" {
     pub fn uffparser_parse(
         uff_parser: *const UffParser_t,
         file: *const ::std::os::raw::c_char,
-        network: *mut Network_t,
+        network: *const Network_t,
     ) -> bool;
 }
 #[repr(C)]

--- a/tensorrt-sys/trt-sys/CMakeLists.txt
+++ b/tensorrt-sys/trt-sys/CMakeLists.txt
@@ -19,6 +19,8 @@ file(GLOB source_files
         "TRTBuilder/*.cpp"
         "TRTNetworkDefinition/*.h"
         "TRTNetworkDefinition/*.cpp"
+        "TRTHostMemory/*.h"
+        "TRTHostMemory/*.cpp"
         "*.h"
         )
 

--- a/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.cpp
+++ b/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.cpp
@@ -59,7 +59,7 @@ Context_t* engine_create_execution_context(Engine_t* engine) {
     return create_execution_context(context);
 }
 
-HostMemory_t* engine_seralize(Engine_t* engine) {
+HostMemory_t* engine_serialize(Engine_t* engine) {
     if (engine == nullptr)
         return nullptr;
 

--- a/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.cpp
+++ b/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.cpp
@@ -2,6 +2,7 @@
 // Created by mason on 8/26/19.
 //
 #include <cstdlib>
+
 #include "NvInfer.h"
 #include "TRTCudaEngine.h"
 
@@ -56,4 +57,13 @@ Context_t* engine_create_execution_context(Engine_t* engine) {
     auto en = static_cast<nvinfer1::ICudaEngine *>(engine->internal_engine);
     nvinfer1::IExecutionContext *context = en->createExecutionContext();
     return create_execution_context(context);
+}
+
+HostMemory_t* engine_seralize(Engine_t* engine) {
+    if (engine == nullptr)
+        return nullptr;
+
+    auto en = static_cast<nvinfer1::ICudaEngine *>(engine->internal_engine);
+    nvinfer1::IHostMemory* hostMemory = en->serialize();
+    return create_host_memory(hostMemory);
 }

--- a/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.h
+++ b/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 #include "../TRTContext/TRTContext.h"
+#include "../TRTHostMemory/TRTHostMemory.h"
 
 struct Engine;
 typedef struct Engine Engine_t;
@@ -23,6 +24,7 @@ int get_nb_bindings(Engine_t* engine);
 const char* get_binding_name(Engine_t* engine, int binding_index);
 int get_binding_index(Engine_t *engine, const char* op_name);
 
+HostMemory_t* engine_seralize(Engine_t* engine);
 
 #ifdef __cplusplus
 };

--- a/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.h
+++ b/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.h
@@ -24,7 +24,7 @@ int get_nb_bindings(Engine_t* engine);
 const char* get_binding_name(Engine_t* engine, int binding_index);
 int get_binding_index(Engine_t *engine, const char* op_name);
 
-HostMemory_t* engine_seralize(Engine_t* engine);
+HostMemory_t* engine_serialize(Engine_t* engine);
 
 #ifdef __cplusplus
 };

--- a/tensorrt-sys/trt-sys/TRTHostMemory/TRTHostMemory.cpp
+++ b/tensorrt-sys/trt-sys/TRTHostMemory/TRTHostMemory.cpp
@@ -1,0 +1,34 @@
+//
+// Created by mason on 1/19/20.
+//
+#include <cstdlib>
+#include <NvInfer.h>
+
+#include "TRTHostMemory.h"
+
+struct HostMemory {
+    void* memory;
+};
+
+HostMemory_t* create_host_memory(void* host_memory) {
+    HostMemory_t* h;
+    h = (typeof(h))malloc(sizeof(h));
+    h->memory = host_memory;
+    return h;
+}
+
+void* host_memory_get_data(HostMemory_t* host_memory) {
+    if (host_memory == nullptr)
+        return nullptr;
+
+    auto hostMemory = static_cast<nvinfer1::IHostMemory*>(host_memory->memory);
+    return hostMemory->data();
+}
+
+size_t host_memory_get_size(HostMemory_t* host_memory) {
+    if (host_memory == nullptr)
+        return -1;
+
+    auto hostMemory = static_cast<nvinfer1::IHostMemory*>(host_memory->memory);
+    return hostMemory->size();
+}

--- a/tensorrt-sys/trt-sys/TRTHostMemory/TRTHostMemory.h
+++ b/tensorrt-sys/trt-sys/TRTHostMemory/TRTHostMemory.h
@@ -1,0 +1,27 @@
+//
+// Created by mason on 1/19/20.
+//
+
+#ifndef LIBTRT_TRTHOSTMEMORY_H
+#define LIBTRT_TRTHOSTMEMORY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct HostMemory;
+typedef struct HostMemory HostMemory_t;
+
+HostMemory_t* create_host_memory(void* host_memory);
+
+void* host_memory_get_data(HostMemory_t* host_memory);
+size_t host_memory_get_size(HostMemory_t* host_memory);
+
+#ifdef __cplusplus
+};
+#endif
+
+
+
+
+#endif //LIBTRT_TRTHOSTMEMORY_H

--- a/tensorrt-sys/trt-sys/tensorrt_api.h
+++ b/tensorrt-sys/trt-sys/tensorrt_api.h
@@ -13,5 +13,6 @@
 #include "TRTDims/TRTDims.h"
 #include "TRTBuilder/TRTBuilder.h"
 #include "TRTNetworkDefinition/TRTNetworkDefinition.h"
+#include "TRTHostMemory/TRTHostMemory.h"
 
 #endif //TENSRORT_SYS_TENSORRT_API_H

--- a/tensorrt/Cargo.toml
+++ b/tensorrt/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 # Uncomment when working locally
 #tensorrt-sys = {version = "0.1", path="../tensorrt-sys"}
 
-tensorrt-sys = {version = "0.1.0", git="https://github.com/mstallmo/tensorrt-rs"}
+tensorrt-sys = {version = "0.1.1", git="https://github.com/mstallmo/tensorrt-rs"}


### PR DESCRIPTION
Implementing bindings to the serialize function for ICudaEngine. This returns a pointer to IHostMemory that contains a pointer to the data and size of the data so it can be written to disk to sent over the wire.

This will allow engines created using the Rust library to save the engines themselves to disk without having to re-parse and build from a .uff everytime a model is loaded.

There is still a little question for me around who owns the data that is accessed via the data pointer in IHostMemory. It's not clear to me from the C++ api if the engine still owns this data or if it's given a copy of this data to IHostMemory that can be destroyed. There is a destroy function on the IHostMemory class which kind of points to the data pointer being a copy and not just pointing to the engine's internal data but I don't have any way of confirming that at this point.