### PR TITLE
Publish Sys and Tensorrt-RS to Crates.io

### DIFF
--- a/tensorrt-sys/Cargo.toml
+++ b/tensorrt-sys/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 edition = "2018"
 build = "build.rs"
 repository = "https://github.com/mstallmo/tensorrt-rs"
+description = "Low level wrapper around Nvidia's TensorRT library"
 
 [dependencies]
 libc = "0.2.62"

--- a/tensorrt-sys/Cargo.toml
+++ b/tensorrt-sys/Cargo.toml
@@ -2,8 +2,10 @@
 name = "tensorrt-sys"
 version = "0.1.1"
 authors = ["Mason Stallmo <masonstallmo@gmail.com>"]
+license = "MIT"
 edition = "2018"
 build = "build.rs"
+repository = "https://github.com/mstallmo/tensorrt-rs"
 
 [dependencies]
 libc = "0.2.62"

--- a/tensorrt/Cargo.toml
+++ b/tensorrt/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Mason Stallmo <masonstallmo@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/mstallmo/tensorrt-rs"
 edition = "2018"
+description = "Rust library for using Nvidia's TensorRT deep learning acceleration library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # Uncomment when working locally

--- a/tensorrt/Cargo.toml
+++ b/tensorrt/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
-name = "tensorrt"
+name = "tensorrt-rs"
 version = "0.1.1"
 authors = ["Mason Stallmo <masonstallmo@gmail.com>"]
+license = "MIT"
+repository = "https://github.com/mstallmo/tensorrt-rs"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # Uncomment when working locally
-tensorrt-sys = {version = "0.1", path="../tensorrt-sys"}
-
-#tensorrt-sys = {version = "0.1.1", git="https://github.com/mstallmo/tensorrt-rs"}
+#tensorrt-sys = {version = "0.1", path="../tensorrt-sys"}
+tensorrt-sys = "0.1.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
Minor changes to publish both crates to crates.io. Complteded the required
fields in both Cargo.toml manifests needed to publish to crates.io.

I just changed the name of the Rust crate from tensorrt to tensorrt-rs
to be inline with rust crate naming conventions.