### PR TITLE
Expand build script to be more flexible with respect to TensorRT version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvinfer_plugin_static.a filter=lfs diff=lfs merge=lfs -text
+tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvinfer_static.a filter=lfs diff=lfs merge=lfs -text
+tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvparsers_static.a filter=lfs diff=lfs merge=lfs -text

--- a/tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvinfer_plugin_static.a
+++ b/tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvinfer_plugin_static.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c5e0094984b9462c18d91f9affcc56606e3eeb0ea72322ca452422d6fc0c11b
+size 2636966

--- a/tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvinfer_static.a
+++ b/tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvinfer_static.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92e4c858e3eac82a3f161da87c7c36eb1620672e19210fd2640ec7cfcfdd027b
+size 164301090

--- a/tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvparsers_static.a
+++ b/tensorrt-sys/3rdParty/TensorRT-5.1.5/libnvparsers_static.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:896ac86fd8d9281635d70e63ea077798e49914b0db046d0caf27ad10a8901b7e
+size 4377674

--- a/tensorrt-sys/Cargo.toml
+++ b/tensorrt-sys/Cargo.toml
@@ -13,6 +13,8 @@ default = ["trt-515"]
 
 trt-515 = []
 
+trt-713 = []
+
 [dependencies]
 libc = "0.2.62"
 

--- a/tensorrt-sys/Cargo.toml
+++ b/tensorrt-sys/Cargo.toml
@@ -8,6 +8,11 @@ build = "build.rs"
 repository = "https://github.com/mstallmo/tensorrt-rs"
 description = "Low level wrapper around Nvidia's TensorRT library"
 
+[features]
+default = ["trt-515"]
+
+trt-515 = []
+
 [dependencies]
 libc = "0.2.62"
 

--- a/tensorrt-sys/Cargo.toml
+++ b/tensorrt-sys/Cargo.toml
@@ -11,9 +11,15 @@ description = "Low level wrapper around Nvidia's TensorRT library"
 [features]
 default = ["trt-515"]
 
-trt-515 = []
+trt-515 = ["cuda-101"]
 
 trt-713 = []
+
+cuda-101 = []
+
+cuda-102 = []
+
+cuda-110 = []
 
 [dependencies]
 libc = "0.2.62"

--- a/tensorrt-sys/README.md
+++ b/tensorrt-sys/README.md
@@ -18,10 +18,16 @@ CMake > 3.10
 
 TensorRT-sys' bindings depends on TensorRT 5.1.5 for the bindings to work correctly. While other versions of
 TensorRT *may* work with the bindings there are no guarantees as functions that are boudn to may have been depricated, 
-removed, or changed in future verions of TensorRT.
+removed, or changed in future versions of TensorRT.
 
-The prerequisites enumerated above are expected to be installed in their default location on Linux 
-(/usr/lib/x86_64-linux-gnu/)
+The prerequisites enumerated above are expected to be installed in their default location on Linux. See the [nvidia
+documentation](https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#installing) around TensorRT for 
+further install information.
+
+__Note:__ The tarball installation method described in the TesnorRT documentation is likely to cause major headaches with
+getting everything to link correctly. It is highly recommended to use the package manager method if possible. 
+
+Windows support is not currently supported but should be coming soon!
 
 ### Support Matrix for TensorRT Classes
 Anything not listed below currently does not have any support.

--- a/tensorrt-sys/build.rs
+++ b/tensorrt-sys/build.rs
@@ -43,8 +43,7 @@ fn configuration(full_library_path: &PathBuf) {
         println!("cargo:rustc-link-search=native={}", dst.display());
         println!("cargo:rustc-flags=-l dylib=nvinfer");
         println!("cargo:rustc-flags=-l dylib=nvparsers");
-        println!("cargo:rustc-flags=-L /usr/local/cuda-10.1/lib64");
-        println!("cargo:rustc-flags=-l dylib=cudart");
+        cuda_configuration();
     } else {
         panic!("Invalid nvinfer version found. Expected: libnvinfer.so.5.1.5, Found: {}", full_library_path.to_str().unwrap());
     }
@@ -58,11 +57,28 @@ fn configuration(full_library_path: &PathBuf) {
         println!("cargo:rustc-link-search=native={}", dst.display());
         println!("cargo:rustc-flags=-l dylib=nvinfer");
         println!("cargo:rustc-flags=-l dylib=nvparsers");
-        println!("cargo:rustc-flags=-L /usr/local/cuda-10.2/lib64");
-        println!("cargo:rustc-flags=-l dylib=cudart");
+        cuda_configuration();
     } else {
         panic!("Invalid nvinfer version found. Expected: libnvinfer.so.7.1.3, Found: {}", full_library_path.to_str().unwrap());
     }
+}
+
+#[cfg(feature = "cuda-101")]
+fn cuda_configuration() {
+    println!("cargo:rustc-flags=-L /usr/local/cuda-10.1/lib64");
+    println!("cargo:rustc-flags=-l dylib=cudart");
+}
+
+#[cfg(feature = "cuda-102")]
+fn cuda_configuration() {
+    println!("cargo:rustc-flags=-L /usr/local/cuda-10.2/lib64");
+    println!("cargo:rustc-flags=-l dylib=cudart");
+}
+
+#[cfg(feature = "cuda-110")]
+fn cuda_configuration() {
+    println!("cargo:rustc-flags=-L /usr/local/cuda-11.0/lib64");
+    println!("cargo:rustc-flags=-l dylib=cudart");
 }
 
 // Not sure if I love this solution but I think it's relatively robust enough for now on Unix systems.

--- a/tensorrt-sys/build.rs
+++ b/tensorrt-sys/build.rs
@@ -43,6 +43,8 @@ fn configuration(full_library_path: &PathBuf) {
         println!("cargo:rustc-link-search=native={}", dst.display());
         println!("cargo:rustc-flags=-l dylib=nvinfer");
         println!("cargo:rustc-flags=-l dylib=nvparsers");
+        println!("cargo:rustc-flags=-L {}/3rdParty/TensorRT-5.1.5", env!("CARGO_MANIFEST_DIR"));
+        println!("cargo:rustc-flags=-l static=nvinfer_plugin_static");
         cuda_configuration();
     } else {
         panic!("Invalid nvinfer version found. Expected: libnvinfer.so.5.1.5, Found: {}", full_library_path.to_str().unwrap());
@@ -67,6 +69,9 @@ fn configuration(full_library_path: &PathBuf) {
 fn cuda_configuration() {
     println!("cargo:rustc-flags=-L /usr/local/cuda-10.1/lib64");
     println!("cargo:rustc-flags=-l dylib=cudart");
+    println!("cargo:rustc-flags=-l dylib=cublas");
+    println!("cargo:rustc-flags=-l dylib=cublasLt");
+    println!("cargo:rustc-flags=-l dylib=cudnn");
 }
 
 #[cfg(feature = "cuda-102")]

--- a/tensorrt-sys/build.rs
+++ b/tensorrt-sys/build.rs
@@ -1,13 +1,27 @@
 use cmake::Config;
+use std::env;
 
+//TODO: Finish this linker path and implement for 7.1.0
+// Figure out why the ldd for the example executable is still finding the nvinfer at the default
+// location instead of our installed location. Potentially look into making the trt-sys library a
+// dynamic library instead of static to handle the linking there rather than dealing with it on the
+// Rust side.
 fn main() {
-    let dst = Config::new("trt-sys").build();
-
-    println!("cargo:rustc-link-search=native={}", dst.display());
+    let mut config = Config::new("trt-sys");
     println!("cargo:rustc-link-lib=static=trt-sys");
     println!("cargo:rustc-flags=-l dylib=stdc++");
-    println!("cargo:rustc-flags=-l dylib=nvinfer");
-    println!("cargo:rustc-flags=-l dylib=nvparsers");
-    println!("cargo:rustc-flags=-L /usr/local/cuda/lib64");
-    println!("cargo:rustc-flags=-l dylib=cudart");
+
+    #[cfg(feature = "trt-515")]
+    {
+        let dst = config.define("TRT_VERSION", "5.1.5").build();
+        let curr_dir = env::current_dir().unwrap();
+        println!("current directory: {}", curr_dir.display());
+        println!("library directory: {}/trt-sys/libs/TensorRT-5.1.5.0/lib", curr_dir.display());
+        println!("cargo:rustc-link-search=native={}", dst.display());
+        println!("cargo:rustc-flags=-L {}/trt-sys/libs/TensorRT-5.1.5.0/lib", curr_dir.display());
+        println!("cargo:rustc-flags=-l dylib=nvinfer");
+        println!("cargo:rustc-flags=-l dylib=nvparsers");
+        println!("cargo:rustc-flags=-L /usr/local/cuda-10.1/lib64");
+        println!("cargo:rustc-flags=-l dylib=cudart");
+    }
 }

--- a/tensorrt-sys/build.rs
+++ b/tensorrt-sys/build.rs
@@ -1,27 +1,94 @@
 use cmake::Config;
-use std::env;
+use std::process::Command;
+use std::string::String;
+use std::process::Stdio;
+use std::path::PathBuf;
 
-//TODO: Finish this linker path and implement for 7.1.0
-// Figure out why the ldd for the example executable is still finding the nvinfer at the default
-// location instead of our installed location. Potentially look into making the trt-sys library a
-// dynamic library instead of static to handle the linking there rather than dealing with it on the
-// Rust side.
-fn main() {
-    let mut config = Config::new("trt-sys");
-    println!("cargo:rustc-link-lib=static=trt-sys");
-    println!("cargo:rustc-flags=-l dylib=stdc++");
+fn get_shared_lib_link_path(library_name: &str) -> Option<PathBuf> {
+    match get_all_possible_link_paths(library_name) {
+        Some(all_link_paths) => {
+            for line in all_link_paths.lines() {
+                if line.ends_with(&format!("{}.so", library_name)) {
+                    let link_path = line.split("=>").collect::<Vec<&str>>().last().unwrap().to_owned();
+                    println!("link path: {}", link_path);
+                    return Some(PathBuf::from(link_path.trim().to_owned()));
+                }
+            }
+            None
+        }
+        None => {
+            None
+        }
+    }
+}
 
-    #[cfg(feature = "trt-515")]
-    {
+fn get_all_possible_link_paths(library_name: &str) -> Option<String> {
+    let mut ld_config = Command::new("ldconfig").arg("-p").stdout(Stdio::piped()).spawn().expect("Failed to run ldconfig");
+
+    if let Some(ld_config_output) = ld_config.stdout.take() {
+        let grep_config = Command::new("grep").arg(library_name).stdin(ld_config_output).stdout(Stdio::piped()).spawn().unwrap();
+        let grep_stdout = grep_config.wait_with_output().unwrap();
+        ld_config.wait().unwrap();
+        Some(String::from_utf8(grep_stdout.stdout).unwrap())
+    } else {
+        None
+    }
+}
+
+#[cfg(feature = "trt-515")]
+fn configuration(full_library_path: &PathBuf) {
+    if full_library_path.to_str().unwrap().ends_with("5.1.5") {
+        let mut config = Config::new("trt-sys");
         let dst = config.define("TRT_VERSION", "5.1.5").build();
-        let curr_dir = env::current_dir().unwrap();
-        println!("current directory: {}", curr_dir.display());
-        println!("library directory: {}/trt-sys/libs/TensorRT-5.1.5.0/lib", curr_dir.display());
         println!("cargo:rustc-link-search=native={}", dst.display());
-        println!("cargo:rustc-flags=-L {}/trt-sys/libs/TensorRT-5.1.5.0/lib", curr_dir.display());
         println!("cargo:rustc-flags=-l dylib=nvinfer");
         println!("cargo:rustc-flags=-l dylib=nvparsers");
         println!("cargo:rustc-flags=-L /usr/local/cuda-10.1/lib64");
         println!("cargo:rustc-flags=-l dylib=cudart");
+    } else {
+        panic!("Invalid nvinfer version found. Expected: libnvinfer.so.5.1.5, Found: {}", full_library_path.to_str().unwrap());
+    }
+}
+
+#[cfg(feature = "trt-713")]
+fn configuration(full_library_path: &PathBuf) {
+    if full_library_path.to_str().unwrap().ends_with("7.1.3") {
+        let mut config = Config::new("trt-sys");
+        let dst = config.define("TRT_VERSION", "7.1.3").build();
+        println!("cargo:rustc-link-search=native={}", dst.display());
+        println!("cargo:rustc-flags=-l dylib=nvinfer");
+        println!("cargo:rustc-flags=-l dylib=nvparsers");
+        println!("cargo:rustc-flags=-L /usr/local/cuda-10.2/lib64");
+        println!("cargo:rustc-flags=-l dylib=cudart");
+    } else {
+        panic!("Invalid nvinfer version found. Expected: libnvinfer.so.7.1.3, Found: {}", full_library_path.to_str().unwrap());
+    }
+}
+
+// Not sure if I love this solution but I think it's relatively robust enough for now on Unix systems.
+// Still have to thoroughly test what happens with a TRT library installed that's not done by the
+// dpkg. It's possible that we'll just have to fall back to only supporting one system library and assuming that
+// the user has the correct library installed and is viewable via ldconfig.
+//
+// Hopefully something like this will work for Windows installs as well, not having a default library
+// install location will make that significantly harder.
+fn main() {
+    println!("cargo:rustc-link-lib=static=trt-sys");
+    println!("cargo:rustc-flags=-l dylib=stdc++");
+
+    match get_shared_lib_link_path("libnvinfer") {
+       Some(link_path) => {
+          match std::fs::read_link(link_path) {
+              Ok(full_library_path) => {
+                  configuration(&full_library_path);
+              },
+              Err(_) => {
+                  panic!("libnvinfer.so not found! See https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-515/tensorrt-install-guide/index.html for install instructions");
+              }
+          }
+       },
+       None => {
+           panic!("libnvinfer.so not found! See https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-515/tensorrt-install-guide/index.html for install instructions");
+       }
     }
 }

--- a/tensorrt-sys/src/lib.rs
+++ b/tensorrt-sys/src/lib.rs
@@ -20,6 +20,7 @@ mod tests {
     use std::io::prelude::*;
     use std::os::raw::{c_char, c_int, c_void};
 
+    #[cfg(feature = "trt-515")]
     #[test]
     fn tensorrt_version() {
         let mut c_buf = Vec::<c_char>::with_capacity(6);
@@ -28,97 +29,12 @@ mod tests {
         assert_eq!("5.1.5", c_str.to_str().unwrap());
     }
 
-    //    #[test]
-    //    fn cuda_runtime() {
-    //        let logger = unsafe { create_logger() };
-    //        let runtime = unsafe { create_infer_runtime(logger) };
-    //
-    //        let mut f = File::open("resnet34-unet-Aug25-07-25-16-best.engine").unwrap();
-    //        let mut buffer = Vec::new();
-    //        f.read_to_end(&mut buffer).unwrap();
-    //        let engine = unsafe {
-    //            deserialize_cuda_engine(
-    //                runtime,
-    //                buffer.as_ptr() as *const c_void,
-    //                buffer.len() as u64,
-    //            )
-    //        };
-    //
-    //        let bindingNameCStr = unsafe {
-    //            let bindingName = get_binding_name(engine, 0);
-    //            CStr::from_ptr(bindingName)
-    //        };
-    //        println!(
-    //            "Binding name for index {} is {}",
-    //            0,
-    //            bindingNameCStr.to_str().unwrap()
-    //        );
-    //
-    //        let execution_context = unsafe { engine_create_execution_context(engine) };
-    //        unsafe { context_set_name(execution_context, CString::new("Mason").unwrap().as_ptr()) };
-    //        let context_name_cstr = unsafe {
-    //            let context_name = context_get_name(execution_context);
-    //            CStr::from_ptr(context_name)
-    //        };
-    //        println!("Context name is {}", context_name_cstr.to_str().unwrap());
-    //
-    //        let input_binding =
-    //            unsafe { get_binding_index(engine, CString::new("data").unwrap().as_ptr()) };
-    //        println!("Binding index for data is {}", input_binding);
-    //
-    //        unsafe {
-    //            destroy_excecution_context(execution_context);
-    //            destroy_cuda_engine(engine);
-    //            destroy_infer_runtime(runtime);
-    //            delete_logger(logger);
-    //        }
-    //    }
-    //
-    //    #[test]
-    //    fn host_memory() {
-    //        let logger = unsafe { create_logger() };
-    //        let runtime = unsafe { create_infer_runtime(logger) };
-    //
-    //        let mut f = File::open("resnet34-unet-Aug25-07-25-16-best.engine").unwrap();
-    //        let mut buffer = Vec::new();
-    //        f.read_to_end(&mut buffer).unwrap();
-    //        let engine = unsafe {
-    //            deserialize_cuda_engine(
-    //                runtime,
-    //                buffer.as_ptr() as *const c_void,
-    //                buffer.len() as u64,
-    //            )
-    //        };
-    //
-    //        let host_memory = unsafe { engine_serialize(engine) };
-    //        let memory_sise = unsafe { host_memory_get_size(host_memory) };
-    //        println!("Host Memory Size of Engine: {}", memory_sise);
-    //    }
-
+    #[cfg(feature = "trt-713")]
     #[test]
-    fn uff_parser() {
-        let parser = unsafe { uffparser_create_uff_parser() };
-        let mut d_vec = vec![3, 256, 256];
-        let mut type_vec = vec![1, 0, 0];
-        let dims = unsafe {
-            crate::create_dims(
-                3,
-                d_vec.as_mut_ptr() as *mut c_int,
-                type_vec.as_mut_ptr() as *mut c_int,
-            )
-        };
-        let input_ret = unsafe {
-            uffparser_register_input(parser, CString::new("input").unwrap().as_ptr(), dims)
-        };
-        assert_eq!(input_ret, true);
-
-        let output_ret = unsafe {
-            uffparser_register_output(parser, CString::new("sigmoid/Sigmoid").unwrap().as_ptr())
-        };
-        assert_eq!(output_ret, true);
-
-        unsafe {
-            uffparser_destroy_uff_parser(parser);
-        }
+    fn tensorrt_version() {
+        let mut c_buf = Vec::<c_char>::with_capacity(6);
+        unsafe { get_tensorrt_version(c_buf.as_mut_ptr()) };
+        let c_str = unsafe { CStr::from_ptr(c_buf.as_ptr()) };
+        assert_eq!("7.1.3", c_str.to_str().unwrap());
     }
 }

--- a/tensorrt-sys/trt-sys/CMakeLists.txt
+++ b/tensorrt-sys/trt-sys/CMakeLists.txt
@@ -22,10 +22,7 @@ file(GLOB source_files
         "TRTHostMemory/*.cpp"
         )
 
-find_library(CUDART_LIBRARY cudart ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
-
 add_library(trt-sys STATIC ${source_files})
-target_link_libraries(trt-sys PRIVATE nvinfer ${CUDART_LIBRARY})
 include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 
 install(TARGETS trt-sys DESTINATION .)

--- a/tensorrt-sys/trt-sys/CMakeLists.txt
+++ b/tensorrt-sys/trt-sys/CMakeLists.txt
@@ -1,30 +1,25 @@
 cmake_minimum_required(VERSION 3.10)
 project(LibTRT LANGUAGES CXX CUDA)
 
+if(${TRT_VERSION} MATCHES "5.1.5")
+    message(STATUS "TRT version is ${TRT_VERSION}")
+    add_definitions(-DTRT_VERSION="${TRT_VERSION}")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_FLAGS "-O3 -Wall -Wextra -Werror -Wno-unknown-pragmas")
 
 file(GLOB source_files
-        "TRTLogger/*.h"
         "TRTLogger/*.cpp"
-        "TRTRuntime/*.h"
         "TRTRuntime/*cpp"
-        "TRTCudaEngine/*.h"
         "TRTCudaEngine/*.cpp"
-        "TRTContext/*.h"
         "TRTContext/*.cpp"
-        "TRTUffParser/*.h"
         "TRTUffParser/*.cpp"
-        "TRTDims/*.h"
         "TRTDims/*.cpp"
-        "TRTBuilder/*.h"
         "TRTBuilder/*.cpp"
-        "TRTNetworkDefinition/*.h"
         "TRTNetworkDefinition/*.cpp"
-        "TRTHostMemory/*.h"
         "TRTHostMemory/*.cpp"
-        "*.h"
         )
 
 find_library(CUDART_LIBRARY cudart ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})

--- a/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
+++ b/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
@@ -1,8 +1,6 @@
 //
 // Created by mason on 9/17/19.
 //
-#include <cstdlib>
-#include <iostream>
 #include <memory>
 #include <cuda_runtime.h>
 #include "NvInfer.h"
@@ -48,10 +46,6 @@ const char* context_get_name(Context_t *execution_context) {
     if (execution_context == nullptr)
         return;
     auto& context = execution_context->internal_context;
-
-#ifdef TRT_VERSION
-    std::cout << "TRT Version: " << TRT_VERSION << "\n";
-#endif
 
     void* buffers[2];
     cudaMalloc(&buffers[0], input_data_size);

--- a/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
+++ b/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
@@ -2,6 +2,7 @@
 // Created by mason on 9/17/19.
 //
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <cuda_runtime.h>
 #include "NvInfer.h"
@@ -47,6 +48,10 @@ const char* context_get_name(Context_t *execution_context) {
     if (execution_context == nullptr)
         return;
     auto& context = execution_context->internal_context;
+
+#ifdef TRT_VERSION
+    std::cout << "TRT Version: " << TRT_VERSION << "\n";
+#endif
 
     void* buffers[2];
     cudaMalloc(&buffers[0], input_data_size);

--- a/tensorrt/Cargo.toml
+++ b/tensorrt/Cargo.toml
@@ -10,8 +10,8 @@ description = "Rust library for using Nvidia's TensorRT deep learning accelerati
 
 [dependencies]
 # Uncomment when working locally
-#tensorrt-sys = {version = "0.2", path="../tensorrt-sys"}
-tensorrt-sys = "0.2.1"
+tensorrt-sys = {version = "0.2", path="../tensorrt-sys"}
+#tensorrt-sys = "0.2.1"
 ndarray = "0.13.1"
 ndarray-image = "0.2.1"
 image = "0.23.9"


### PR DESCRIPTION
This is an admittedly rough PR. This work represents an attempt to make the build script for tensorrt-sys more flexible around the version of TensorRT that are linked. This system is far from perfect or complete but I think it's an important step forward on the native build side.

TensorRT's install method makes it a tricky library to bind in Rust at least until we have specific linker flags exposed to cargo. We are pretty dependent on the correct version (5.1.5 at the time of this PR) to be installed on the system by default and don't have a great story around making the crate as usable for people as possible. 

This is still very much an area of continuing work.