### PR TITLE
Circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+# Use a package of configuration called an orb.
+orbs:
+  # Declare a dependency on the welcome-orb
+  welcome: circleci/welcome-orb@0.4.1
+# Orchestrate or schedule a set of jobs
+workflows:
+  # Name the workflow "welcome"
+  welcome:
+    # Run the welcome/run job in its own container
+    jobs:
+      - welcome/run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: mstallmo/tensorrt-rs:0.1
     steps:
+      - checkout
       - run: ls
 # Orchestrate or schedule a set of jobs
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: mstallmo/tensorrt-rs:0.1
+      - image: mstallmo/tensorrt-rs:0.2
     steps:
       - checkout
       - run: cargo build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: mstallmo/tensorrt-rs:0.1
     steps:
-      - run: cargo --version
+      - run: cargo build
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,6 @@ jobs:
           root: /root
           paths:
             - project
-  # Running tests are currently broken due to an -fPIC issue in docker. Could be related to the shared libs that are
-  # installed by default in the nvidia container that we're using as a base.
   test-tensorrt-sys:
     docker:
       - image: mstallmo/tensorrt-rs:0.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
           root: /root
           paths:
             - project
+  # Running tests are currently broken due to an -fPIC issue in docker. Could be related to the shared libs that are
+  # installed by default in the nvidia container that we're using as a base.
   test-tensorrt-sys:
     docker:
       - image: mstallmo/tensorrt-rs:0.2
@@ -18,7 +20,8 @@ jobs:
       - attach_workspace:
           at: /root
       - run: cd tensorrt-sys
-      - run: cargo test
+      - run: pwd
+      - run: ls
 # Orchestrate or schedule a set of jobs
 workflows:
   build-docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: mstallmo/tensorrt-rs:0.1
     steps:
       - checkout
-      - run: ls
+      - run: cargo build
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: nvcr.io/nvidia/tensorrt:19.06-py3
+      - image: mstallmo/tensorrt-rs:0.1
     steps:
-      - run: ls /usr/lib/x86_64-linux-gnu | grep libnvinf
+      - run: cargo --version
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,9 @@ jobs:
       - image: mstallmo/tensorrt-rs:0.2
     steps:
       - checkout
-      - run: cargo build
+      - run: cargo build --release
 # Orchestrate or schedule a set of jobs
 workflows:
-  # Name the workflow "welcome"
-  welcome:
-    # Run the welcome/run job in its own container
+  build-docker:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,16 @@ jobs:
     steps:
       - checkout
       - run: cargo build --release
+      - persist_to_workspace:
+          root: /root
+          paths:
+            - project
   test-tensorrt-sys:
     docker:
       - image: mstallmo/tensorrt-rs:0.2
     steps:
+      - attach_workspace:
+          at: /root
       - run: cd tensorrt-sys
       - run: cargo test
 # Orchestrate or schedule a set of jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,10 @@
 version: 2.1
 jobs:
   build:
-    machine:
-      resource_class: gpu.nvidia.small
-      image: ubuntu-1604-cuda-10.1:201909-23
+    docker:
+      - image: nvcr.io/nvidia/tensorrt:19.06-py3
     steps:
-      - run: nvidia-smi
-      - run: docker run --gpus all nvidia/cuda:10.1-base nvidia-smi
+      - run: ls /usr/lib/x86_64-linux-gnu | grep libnvinf
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,17 @@ jobs:
     steps:
       - checkout
       - run: cargo build --release
+  test-tensorrt-sys:
+    docker:
+      - image: mstallmo/tensorrt-rs:0.2
+    steps:
+      - run: cd tensorrt-sys
+      - run: cargo test
 # Orchestrate or schedule a set of jobs
 workflows:
   build-docker:
     jobs:
       - build
+      - test-tensorrt-sys:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: mstallmo/tensorrt-rs:0.1
     steps:
-      - run: cargo build
+      - run: ls
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /root
-      - run: cd tensorrt-sys
-      - run: pwd
-      - run: ls
+      - run: cd tensorrt-sys && cargo test
 # Orchestrate or schedule a set of jobs
 workflows:
   build-docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,10 @@ workflows:
   welcome:
     # Run the welcome/run job in its own container
     jobs:
-      - welcome/run
+      build:
+        machine:
+          resource_class: gpu.nvidia.small
+          image: ubuntu-1604-cuda-10.1:201909-23
+        steps:
+          - run: nvidia-smi
+          - run: docker run --gpus all nvidia/cuda:10.1-base nvidia-smi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,17 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-# Use a package of configuration called an orb.
-orbs:
-  # Declare a dependency on the welcome-orb
-  welcome: circleci/welcome-orb@0.4.1
+jobs:
+  build:
+    machine:
+      resource_class: gpu.nvidia.small
+      image: ubuntu-1604-cuda-10.1:201909-23
+    steps:
+      - run: nvidia-smi
+      - run: docker run --gpus all nvidia/cuda:10.1-base nvidia-smi
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"
   welcome:
     # Run the welcome/run job in its own container
     jobs:
-      build:
-        machine:
-          resource_class: gpu.nvidia.small
-          image: ubuntu-1604-cuda-10.1:201909-23
-        steps:
-          - run: nvidia-smi
-          - run: docker run --gpus all nvidia/cuda:10.1-base nvidia-smi
+      - build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM nvcr.io/nvidia/tensorrt:19.06-py3
 
+RUN apt-get update
+RUN apt install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update
+RUN apt-get install g++-7 -y
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-7
+RUN update-alternatives --config gcc
+RUN gcc --version
+RUN g++ --version
+
 # Download and install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM nvcr.io/nvidia/tensorrt:19.06-py3
+
+# Download and install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+#Add Cargo executables to path
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Check version
+RUN cargo --version

--- a/tensorrt-sys/trt-sys/CMakeLists.txt
+++ b/tensorrt-sys/trt-sys/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
-set(CMAKE_CXX_FLAGS "-O3 -Wall -Wextra -Werror -Wno-unknown-pragmas")
+set(CMAKE_CXX_FLAGS "-fPIC -O3 -Wall -Wextra -Werror -Wno-unknown-pragmas")
 
 file(GLOB source_files
         "TRTLogger/*.cpp"


### PR DESCRIPTION
Closes #19 

Setup basic building and testing on CircleCI. Only the tensorrt-sys tests are currently run because they can run independently of having a GPU enabled. I believe as long as we're careful writing unit tests we'll be able to run all the tests on CI builds even on machines without GPU support.

We will mostly have to stay away from testing actual model execution on CI because that will fail due to the lack of GPU. Everything else I believe will work but the current test suite needs to be cleaned up before that can be enabled. Those tests start to stray into integration tests anyways so I'm okay with not running actual model executions for the time being. 

Might be worth emailing CircleCI to see if an OSS project that needs GPUs for integration tests can get access to those images on their free tier. 