### PR TITLE
Test and example error cleanup

### DIFF
--- a/tensorrt-sys/src/lib.rs
+++ b/tensorrt-sys/src/lib.rs
@@ -4,19 +4,7 @@
 
 include!("bindings.rs");
 
-#[cfg(test)]
-mod tests {
-    use crate::{
-        context_get_name, context_set_name, create_infer_runtime, create_logger, delete_logger,
-        deserialize_cuda_engine, destroy_cuda_engine, destroy_excecution_context,
-        destroy_infer_runtime, engine_create_execution_context, engine_serialize,
-        get_binding_index, get_binding_name, get_tensorrt_version, host_memory_get_size,
-        uffparser_create_uff_parser, uffparser_destroy_uff_parser, uffparser_register_input,
-        uffparser_register_output,
-    };
-    use std::ffi::CStr;
-    use std::ffi::CString;
-    use std::fs::File;
-    use std::io::prelude::*;
-    use std::os::raw::{c_char, c_int, c_void};
-}
+// #[cfg(test)]
+// mod tests {
+//     use crate::get_tensorrt_version;
+// }

--- a/tensorrt/Cargo.toml
+++ b/tensorrt/Cargo.toml
@@ -24,7 +24,13 @@ tensorrt-sys = { path = "../tensorrt-sys"}
 ndarray = "0.13"
 ndarray-image = "0.2"
 image = "0.23"
+imageproc = "0.21.0"
 bitflags = "1.2"
 
 [dev-dependencies]
 lazy_static = "1.4"
+
+
+[[example]]
+name = "onnx"
+required-features = ["trt-7"]

--- a/tensorrt/examples/mnist_uff/main.rs
+++ b/tensorrt/examples/mnist_uff/main.rs
@@ -3,6 +3,7 @@ use ndarray_image;
 use std::iter::FromIterator;
 use std::path::Path;
 use tensorrt_rs::builder::Builder;
+use tensorrt_rs::context::ExecuteInput;
 use tensorrt_rs::dims::DimsCHW;
 use tensorrt_rs::engine::Engine;
 use tensorrt_rs::runtime::Logger;
@@ -43,7 +44,7 @@ fn main() {
 
     // Run inference
     let mut output = ndarray::Array1::<f32>::zeros(10);
-    let outputs = vec![&mut output];
-    context.execute(&pre_processed, &outputs, 2);
-    println!("output: {}", outputs[0]);
+    let outputs = vec![ExecuteInput::Float(&mut output)];
+    context.execute(ExecuteInput::Float(&pre_processed), outputs, 2);
+    println!("output: {}", output);
 }

--- a/tensorrt/src/runtime.rs
+++ b/tensorrt/src/runtime.rs
@@ -33,6 +33,8 @@ impl Logger {
     }
 }
 
+unsafe impl Send for Logger {}
+
 impl Drop for Logger {
     fn drop(&mut self) {
         unsafe { delete_logger(self.internal_logger) };
@@ -59,13 +61,5 @@ impl<'a> Runtime<'a> {
 impl<'a> Drop for Runtime<'a> {
     fn drop(&mut self) {
         unsafe { destroy_infer_runtime(self.internal_runtime) };
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
     }
 }


### PR DESCRIPTION
Cleanup some minor leftover errors after merging the PR to include Onnx support and support for TensorRT 6.x+ APIs.

I also re-worked the tests for engine to line up with the new changes as well. This mostly consisted of making logger a lazy static object so we can pass the same logger to each function that creates a new engine.

We have to handle it this way with the logger because TensorRT considers the logger to be a singleton so multiple instances of builder and runtime have to be passed the same instance of logger or we're gonna have a bad time.