### PR TITLE
Implementation of IExecutionContext

### DIFF
--- a/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
+++ b/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
@@ -29,6 +29,14 @@ void destroy_excecution_context(Context_t *execution_context) {
     delete execution_context;
 }
 
+void context_set_debug_sync(Context_t *execution_context, bool sync) {
+    execution_context->internal_context->setDebugSync(sync);
+}
+
+bool context_get_debug_sync(Context_t *execution_context) {
+    return execution_context->internal_context->getDebugSync();
+}
+
 void context_set_name(Context_t *execution_context, const char *name) {
     if (execution_context == nullptr)
         return;

--- a/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
+++ b/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
@@ -18,7 +18,9 @@ struct Context {
     }
 
     ~Context() {
-        _concreteProfiler->destroy();
+        if (_concreteProfiler) {
+            _concreteProfiler->destroy();
+        }
     }
 
     ConcreteProfiler* _concreteProfiler = nullptr;
@@ -59,7 +61,6 @@ const char *context_get_name(Context_t *execution_context) {
 
 void context_set_profiler(Context_t *context, Profiler_t *profiler) {
     auto concreteProfiler = new ConcreteProfiler(profiler);
-    concreteProfiler->reportLayerTime("Test layer name", 0.005);
     context->_concreteProfiler = concreteProfiler;
     context->internal_context->setProfiler(concreteProfiler);
 }

--- a/tensorrt-sys/trt-sys/TRTContext/TRTContext.h
+++ b/tensorrt-sys/trt-sys/TRTContext/TRTContext.h
@@ -8,6 +8,7 @@
 #define LIBTRT_TRTCONTEXT_H
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,6 +18,9 @@ struct Context;
 typedef struct Context Context_t;
 
 void destroy_excecution_context(Context_t* execution_context);
+
+void context_set_debug_sync(Context_t* execution_context, bool sync);
+bool context_get_debug_sync(Context_t* execution_context);
 
 void context_set_name(Context_t* execution_context, const char *name);
 const char* context_get_name(Context_t *execution_context);

--- a/tensorrt-sys/trt-sys/TRTContext/TRTContext.h
+++ b/tensorrt-sys/trt-sys/TRTContext/TRTContext.h
@@ -10,6 +10,8 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#include "../TRTProfiler/TRTProfiler.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -24,6 +26,9 @@ bool context_get_debug_sync(Context_t* execution_context);
 
 void context_set_name(Context_t* execution_context, const char *name);
 const char* context_get_name(Context_t *execution_context);
+
+void context_set_profiler(Context_t* execution_context, Profiler_t* profiler);
+Profiler_t* context_get_profiler(Context_t *execution_context);
 
 void execute(const Context_t* execution_context, const void** binding_data, const int num_bindings, const size_t* data_sizes);
 

--- a/tensorrt-sys/trt-sys/TRTProfiler/TRTProfiler.h
+++ b/tensorrt-sys/trt-sys/TRTProfiler/TRTProfiler.h
@@ -1,0 +1,19 @@
+//
+// Created by mason on 10/7/20.
+//
+
+#ifndef LIBTRT_TRTPROFILER_H
+#define LIBTRT_TRTPROFILER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct Profiler;
+typedef struct Profiler Profiler_t;
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif //LIBTRT_TRTPROFILER_H

--- a/tensorrt-sys/trt-sys/TRTProfiler/TRTProfilerInternal.hpp
+++ b/tensorrt-sys/trt-sys/TRTProfiler/TRTProfilerInternal.hpp
@@ -1,0 +1,37 @@
+//
+// Created by mason on 10/7/20.
+//
+
+#ifndef LIBTRT_TRTPROFILERINTERNAL_HPP
+#define LIBTRT_TRTPROFILERINTERNAL_HPP
+
+#include "TRTProfiler.h"
+#include <NvInfer.h>
+
+struct Profiler {
+    void (*reportLayerTime)(void *context, const char *layerName, float ms);
+    void (*destroy)(void *self, void* context);
+    void* context;
+};
+
+class ConcreteProfiler : public nvinfer1::IProfiler {
+public:
+    explicit ConcreteProfiler(Profiler_t *_profiler) : profiler(_profiler) {}
+
+    void reportLayerTime(const char* layerName, float ms) override {
+        (*profiler->reportLayerTime)(profiler->context, layerName, ms);
+    }
+
+    void destroy() {
+        (*profiler->destroy)(profiler, profiler->context);
+    }
+
+    Profiler_t* getInternalProfiler() {
+        return profiler;
+    }
+
+private:
+    Profiler_t *profiler;
+};
+
+#endif //LIBTRT_TRTPROFILERINTERNAL_HPP

--- a/tensorrt-sys/trt-sys/tensorrt_api.h
+++ b/tensorrt-sys/trt-sys/tensorrt_api.h
@@ -15,5 +15,6 @@
 #include "TRTBuilder/TRTBuilder.h"
 #include "TRTNetworkDefinition/TRTNetworkDefinition.h"
 #include "TRTHostMemory/TRTHostMemory.h"
+#include "TRTProfiler/TRTProfiler.h"
 
 #endif //TENSRORT_SYS_TENSORRT_API_H

--- a/tensorrt/src/context.rs
+++ b/tensorrt/src/context.rs
@@ -1,10 +1,9 @@
-use crate::engine::Engine;
 use crate::profiler::{IProfiler, ProfilerBinding};
 use ndarray;
 use ndarray::Dimension;
 use std::ffi::{CStr, CString};
 use std::mem::size_of;
-use std::os::raw::{c_char, c_void};
+use std::os::raw::c_void;
 use std::vec::Vec;
 use tensorrt_sys::{
     context_get_debug_sync, context_get_name, context_get_profiler, context_set_debug_sync,

--- a/tensorrt/src/engine.rs
+++ b/tensorrt/src/engine.rs
@@ -6,6 +6,7 @@ use std::slice;
 
 use crate::context::Context;
 use crate::dims::Dims;
+use crate::profiler::RustProfiler;
 use crate::runtime::{Logger, Runtime};
 use tensorrt_sys::{
     deserialize_cuda_engine, destroy_cuda_engine, destroy_host_memory,

--- a/tensorrt/src/engine.rs
+++ b/tensorrt/src/engine.rs
@@ -6,7 +6,6 @@ use std::slice;
 
 use crate::context::Context;
 use crate::dims::Dims;
-use crate::profiler::RustProfiler;
 use crate::runtime::{Logger, Runtime};
 use tensorrt_sys::{
     deserialize_cuda_engine, destroy_cuda_engine, destroy_host_memory,

--- a/tensorrt/src/lib.rs
+++ b/tensorrt/src/lib.rs
@@ -7,5 +7,6 @@ pub mod dims;
 pub mod engine;
 pub mod network;
 pub mod onnx;
+pub mod profiler;
 pub mod runtime;
 pub mod uff;

--- a/tensorrt/src/profiler.rs
+++ b/tensorrt/src/profiler.rs
@@ -1,0 +1,75 @@
+use std::alloc::{dealloc, Layout};
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::ptr;
+use tensorrt_sys::Profiler_t;
+
+pub trait IProfiler {
+    fn report_layer_time(&self, layer_name: *const c_char, ms: f32);
+}
+
+#[repr(C)]
+pub(crate) struct ProfilerBinding<T>
+where
+    T: IProfiler,
+{
+    pub report_layer_time: unsafe extern "C" fn(*mut T, *const c_char, f32),
+    destroy: unsafe extern "C" fn(*mut Profiler_t, *mut T),
+    pub context: *mut T,
+}
+
+impl<T> ProfilerBinding<T>
+where
+    T: IProfiler,
+{
+    pub fn new(profiler: &mut T) -> Self {
+        unsafe extern "C" fn report_layer_time<T>(
+            context: *mut T,
+            layer_name: *const c_char,
+            ms: f32,
+        ) where
+            T: IProfiler,
+        {
+            let profiler_ref: &mut T = &mut *context;
+            profiler_ref.report_layer_time(layer_name, ms);
+        }
+
+        //This is a little un-orthodox but having this extern function allows us to
+        //cleanup the memory that we lose when passing the ProfilerBinding as a raw pointer to
+        //the C++ bindings. The pointer that gets sent to C++ becomes owned by a C++ object and when
+        //that object is destroyed this will get called so we can destroy the memory allocated for
+        //the pointer properly.
+        unsafe extern "C" fn destroy<T: IProfiler>(binding: *mut Profiler_t, _: *mut T) {
+            Box::from_raw(binding as *mut ProfilerBinding<T>);
+        }
+
+        let context: *mut T = &mut *profiler;
+        ProfilerBinding {
+            report_layer_time,
+            destroy,
+            context,
+        }
+    }
+
+    pub(crate) unsafe fn from_raw<U: IProfiler>(ptr: *mut Profiler_t) -> Box<Self> {
+        Box::from_raw(ptr as *mut Self)
+    }
+}
+
+pub struct RustProfiler {}
+
+impl RustProfiler {
+    pub fn new() -> Self {
+        RustProfiler {}
+    }
+}
+
+impl IProfiler for RustProfiler {
+    fn report_layer_time(&self, layer_name: *const c_char, ms: f32) {
+        println!(
+            "{} took {} ms",
+            unsafe { CStr::from_ptr(layer_name) }.to_str().unwrap(),
+            ms
+        );
+    }
+}

--- a/tensorrt/src/profiler.rs
+++ b/tensorrt/src/profiler.rs
@@ -1,7 +1,5 @@
-use std::alloc::{dealloc, Layout};
 use std::ffi::CStr;
 use std::os::raw::c_char;
-use std::ptr;
 use tensorrt_sys::Profiler_t;
 
 pub trait IProfiler {
@@ -49,10 +47,6 @@ where
             destroy,
             context,
         }
-    }
-
-    pub(crate) unsafe fn from_raw<U: IProfiler>(ptr: *mut Profiler_t) -> Box<Self> {
-        Box::from_raw(ptr as *mut Self)
     }
 }
 


### PR DESCRIPTION
close #28 

Complete the implementation of the IExecutionContext interface minus `setDeviceMemory`. `setDeviceMemory` is not currently implemented because we don't currently have any facilities to allocate GPU device memory from the rust bindings. To implement this properly we'll have to add bindings to allocating GPU memory from Rust code. Maybe via the `accel` crate? 

I'm going to open an issue tracking `setDeviceMemory` and will get around to implementing that at some point. 