### PR TITLE
Implement IRuntime

### DIFF
--- a/tensorrt-sys/trt-sys/TRTRuntime/TRTRuntime.cpp
+++ b/tensorrt-sys/trt-sys/TRTRuntime/TRTRuntime.cpp
@@ -34,3 +34,14 @@ Engine_t* deserialize_cuda_engine(Runtime_t* runtime, const void* blob, unsigned
     return create_engine(engine);
 }
 
+int runtime_get_nb_dla_cores(Runtime_t *runtime) {
+    return runtime->internal_runtime->getNbDLACores();
+}
+
+int runtime_get_dla_core(Runtime_t *runtime) {
+    return runtime->internal_runtime->getDLACore();
+}
+
+void runtime_set_dla_core(Runtime_t *runtime, int dla_core) {
+    runtime->internal_runtime->setDLACore(dla_core);
+}

--- a/tensorrt-sys/trt-sys/TRTRuntime/TRTRuntime.h
+++ b/tensorrt-sys/trt-sys/TRTRuntime/TRTRuntime.h
@@ -16,8 +16,13 @@ struct Runtime;
 typedef struct Runtime Runtime_t;
 
 Runtime_t* create_infer_runtime(Logger_t* logger);
-Engine_t* deserialize_cuda_engine(Runtime_t* runtime, const void* blob, unsigned long long size);
 void destroy_infer_runtime(Runtime_t* runtime);
+
+Engine_t* deserialize_cuda_engine(Runtime_t* runtime, const void* blob, unsigned long long size);
+int runtime_get_nb_dla_cores(Runtime_t* runtime);
+int runtime_get_dla_core(Runtime_t *runtime);
+void runtime_set_dla_core(Runtime_t *runtime, int dla_core);
+
 
 #ifdef __cplusplus
 };

--- a/tensorrt/examples/ssd_uff/main.rs
+++ b/tensorrt/examples/ssd_uff/main.rs
@@ -10,7 +10,7 @@ use tensorrt_rs::engine::Engine;
 use tensorrt_rs::runtime::Logger;
 use tensorrt_rs::uff::{UffFile, UffInputOrder, UffParser};
 
-fn create_engine<'a>(logger: &'a Logger, uff_file: &UffFile) -> Engine<'a> {
+fn create_engine(logger: &Logger, uff_file: &UffFile) -> Engine {
     let builder = Builder::new(&logger);
     let network = builder.create_network();
 

--- a/tensorrt/src/builder/mod.rs
+++ b/tensorrt/src/builder/mod.rs
@@ -231,14 +231,10 @@ impl<'a> Builder<'a> {
         Network { internal_network }
     }
 
-    pub fn build_cuda_engine(&self, network: &Network) -> Engine<'a> {
+    pub fn build_cuda_engine(&self, network: &Network) -> Engine {
         let internal_engine =
             unsafe { build_cuda_engine(self.internal_builder, network.internal_network) };
-        let logger = self.logger;
-        Engine {
-            internal_engine,
-            logger,
-        }
+        Engine { internal_engine }
     }
 
     pub fn reset(&self, network: Network) {

--- a/tensorrt/src/context.rs
+++ b/tensorrt/src/context.rs
@@ -16,12 +16,12 @@ pub enum ExecuteInput<'a, D: Dimension> {
     Float(&'a ndarray::Array<f32, D>),
 }
 
-pub struct Context<'a, 'b> {
+pub struct Context<'a> {
     pub(crate) internal_context: *mut Context_t,
-    pub(crate) _engine: &'a crate::engine::Engine<'b>,
+    pub(crate) _engine: &'a crate::engine::Engine,
 }
 
-impl<'a, 'b> Context<'a, 'b> {
+impl<'a> Context<'a> {
     pub fn set_debug_sync(&self, sync: bool) {
         unsafe { context_set_debug_sync(self.internal_context, sync) }
     }
@@ -110,7 +110,7 @@ impl<'a, 'b> Context<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Drop for Context<'a, 'b> {
+impl<'a> Drop for Context<'a> {
     fn drop(&mut self) {
         unsafe { destroy_excecution_context(self.internal_context) };
     }

--- a/tensorrt/src/runtime.rs
+++ b/tensorrt/src/runtime.rs
@@ -1,8 +1,11 @@
 use std::marker::PhantomData;
 
+use crate::engine::Engine;
+use bitflags::_core::ffi::c_void;
 use tensorrt_sys::{
-    create_infer_runtime, create_logger, delete_logger, destroy_infer_runtime,
-    runtime_get_dla_core, runtime_get_nb_dla_cores, runtime_set_dla_core, set_logger_severity,
+    create_infer_runtime, create_logger, delete_logger, deserialize_cuda_engine,
+    destroy_infer_runtime, runtime_get_dla_core, runtime_get_nb_dla_cores, runtime_set_dla_core,
+    set_logger_severity,
 };
 
 #[repr(C)]
@@ -56,6 +59,18 @@ impl<'a> Runtime<'a> {
             internal_runtime,
             logger,
         }
+    }
+
+    pub fn deserialize_cuda_engine(&self, buffer: Vec<u8>) -> Engine {
+        let internal_engine = unsafe {
+            deserialize_cuda_engine(
+                self.internal_runtime,
+                buffer.as_ptr() as *const c_void,
+                buffer.len() as u64,
+            )
+        };
+
+        Engine { internal_engine }
     }
 
     pub fn get_nb_dla_cores(&self) -> i32 {


### PR DESCRIPTION
close #29 

This is a complete implementation of the `nvinfer1::IRuntime` interface minus support for setting a custom `nvinfer1::IGpuAllocator` class. We don't have support for properly allocating GPU memory from Rust so we can't support this part of the interface at the current time. Once we have some support for GPU memory allocation this will be implemented.