### PR TITLE
Implement ICudaEngine

### DIFF
--- a/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.cpp
+++ b/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.cpp
@@ -23,28 +23,28 @@ Engine_t* create_engine(nvinfer1::ICudaEngine* engine) {
     return new Engine(engine);
 }
 
-void destroy_cuda_engine(Engine_t* engine) {
+void engine_destroy(Engine_t* engine) {
     if (engine == nullptr)
         return;
 
     delete engine;
 }
 
-int get_nb_bindings(Engine_t* engine) {
+int engine_get_nb_bindings(Engine_t* engine) {
     if (engine == nullptr)
         return -1;
 
     return engine->internal_engine->getNbBindings();
 }
 
-int get_binding_index(Engine_t* engine, const char* op_name) {
+int engine_get_binding_index(Engine_t* engine, const char* op_name) {
     if (engine == nullptr)
         return -1;
 
     return engine->internal_engine->getBindingIndex(op_name);
 }
 
-const char* get_binding_name(Engine_t* engine, int binding_index) {
+const char* engine_get_binding_name(Engine_t* engine, int binding_index) {
     if (engine == nullptr)
         return "";
 
@@ -55,7 +55,7 @@ bool engine_binding_is_input(Engine_t *engine, int binding_index) {
     return engine->internal_engine->bindingIsInput(binding_index);
 }
 
-Dims_t* get_binding_dimensions(Engine_t *engine, int binding_index) {
+Dims_t* engine_get_binding_dimensions(Engine_t *engine, int binding_index) {
     if (engine == nullptr)
         return nullptr;
 

--- a/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.cpp
+++ b/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.cpp
@@ -37,6 +37,13 @@ int get_nb_bindings(Engine_t* engine) {
     return engine->internal_engine->getNbBindings();
 }
 
+int get_binding_index(Engine_t* engine, const char* op_name) {
+    if (engine == nullptr)
+        return -1;
+
+    return engine->internal_engine->getBindingIndex(op_name);
+}
+
 const char* get_binding_name(Engine_t* engine, int binding_index) {
     if (engine == nullptr)
         return "";
@@ -44,11 +51,8 @@ const char* get_binding_name(Engine_t* engine, int binding_index) {
     return engine->internal_engine->getBindingName(binding_index);
 }
 
-int get_binding_index(Engine_t* engine, const char* op_name) {
-    if (engine == nullptr)
-        return -1;
-
-    return engine->internal_engine->getBindingIndex(op_name);
+bool engine_binding_is_input(Engine_t *engine, int binding_index) {
+    return engine->internal_engine->bindingIsInput(binding_index);
 }
 
 Dims_t* get_binding_dimensions(Engine_t *engine, int binding_index) {
@@ -64,6 +68,22 @@ Dims_t* get_binding_dimensions(Engine_t *engine, int binding_index) {
     return dims;
 }
 
+DataType_t engine_get_binding_data_type(Engine_t *engine, int binding_index) {
+    return static_cast<DataType_t>(engine->internal_engine->getBindingDataType(binding_index));
+}
+
+int engine_get_max_batch_size(Engine_t *engine) {
+    return engine->internal_engine->getMaxBatchSize();
+}
+
+int engine_get_nb_layers(Engine_t *engine) {
+    return engine->internal_engine->getNbLayers();
+}
+
+size_t engine_get_workspace_size(Engine_t *engine) {
+    return engine->internal_engine->getWorkspaceSize();
+}
+
 Context_t* engine_create_execution_context(Engine_t* engine) {
     if (engine == nullptr)
         return nullptr;
@@ -72,9 +92,26 @@ Context_t* engine_create_execution_context(Engine_t* engine) {
     return create_execution_context(context);
 }
 
+Context_t* engine_create_execution_context_without_device_memory(Engine_t *engine) {
+    nvinfer1::IExecutionContext *context = engine->internal_engine->createExecutionContextWithoutDeviceMemory();
+    return create_execution_context(context);
+}
+
 HostMemory_t* engine_serialize(Engine_t* engine) {
     if (engine == nullptr)
         return nullptr;
 
     return create_host_memory(engine->internal_engine->serialize());
+}
+
+TensorLocation_t  engine_get_location(Engine_t *engine, int binding_index) {
+    return static_cast<TensorLocation_t>(engine->internal_engine->getLocation(binding_index));
+}
+
+size_t engine_get_device_memory_size(Engine_t *engine) {
+    return engine->internal_engine->getDeviceMemorySize();
+}
+
+bool engine_is_refittable(Engine_t *engine) {
+    return engine->internal_engine->isRefittable();
 }

--- a/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.h
+++ b/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.h
@@ -30,20 +30,20 @@ typedef enum TensorLocation TensorLocation_t;
 struct Engine;
 typedef struct Engine Engine_t;
 
-void destroy_cuda_engine(Engine_t* engine);
+void engine_destroy(Engine_t* engine);
 
 Context_t* engine_create_execution_context(Engine_t* engine);
 Context_t* engine_create_execution_context_without_device_memory(Engine_t *engine);
 
-int get_nb_bindings(Engine_t* engine);
+int engine_get_nb_bindings(Engine_t* engine);
 
-int get_binding_index(Engine_t *engine, const char* op_name);
+int engine_get_binding_index(Engine_t *engine, const char* op_name);
 
-const char* get_binding_name(Engine_t* engine, int binding_index);
+const char* engine_get_binding_name(Engine_t* engine, int binding_index);
 
 bool engine_binding_is_input(Engine_t *engine, int binding_index);
 
-Dims_t* get_binding_dimensions(Engine_t *engine, int binding_index);
+Dims_t* engine_get_binding_dimensions(Engine_t *engine, int binding_index);
 
 DataType_t engine_get_binding_data_type(Engine_t *engine, int binding_index);
 

--- a/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.h
+++ b/tensorrt-sys/trt-sys/TRTCudaEngine/TRTCudaEngine.h
@@ -5,13 +5,27 @@
 #ifndef LIBTRT_TRTCUDAENGINE_H
 #define LIBTRT_TRTCUDAENGINE_H
 
+#include "../TRTContext/TRTContext.h"
+#include "../TRTHostMemory/TRTHostMemory.h"
+#include "../TRTDims/TRTDims.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "../TRTContext/TRTContext.h"
-#include "../TRTHostMemory/TRTHostMemory.h"
-#include "../TRTDims/TRTDims.h"
+enum DataType {
+    kFLOAT = 0,
+    kHALF = 1,
+    kINT8 = 2,
+    kINT32 = 3,
+};
+typedef enum DataType DataType_t;
+
+enum TensorLocation {
+    kDEVICE = 0,
+    kHOST = 1,
+};
+typedef enum TensorLocation TensorLocation_t;
 
 struct Engine;
 typedef struct Engine Engine_t;
@@ -19,13 +33,33 @@ typedef struct Engine Engine_t;
 void destroy_cuda_engine(Engine_t* engine);
 
 Context_t* engine_create_execution_context(Engine_t* engine);
+Context_t* engine_create_execution_context_without_device_memory(Engine_t *engine);
 
 int get_nb_bindings(Engine_t* engine);
-const char* get_binding_name(Engine_t* engine, int binding_index);
+
 int get_binding_index(Engine_t *engine, const char* op_name);
+
+const char* get_binding_name(Engine_t* engine, int binding_index);
+
+bool engine_binding_is_input(Engine_t *engine, int binding_index);
+
 Dims_t* get_binding_dimensions(Engine_t *engine, int binding_index);
 
+DataType_t engine_get_binding_data_type(Engine_t *engine, int binding_index);
+
+int engine_get_max_batch_size(Engine_t *engine);
+
+int engine_get_nb_layers(Engine_t *engine);
+
+size_t engine_get_workspace_size(Engine_t *engine);
+
 HostMemory_t* engine_serialize(Engine_t* engine);
+
+TensorLocation_t engine_get_location(Engine_t *engine, int binding_index);
+
+size_t engine_get_device_memory_size(Engine_t *engine);
+
+bool engine_is_refittable(Engine_t *engine);
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
close #30 

Complete implementation of the `nvinfer1::ICudaEngine` interface. Bindings for creating an execution context without memory are implemented though they can't be properly used currently. This is because we don't currently support the ability to allocate device memory from Rust, once that's in place this feature can be used properly.