### PR TITLE
fixed cfg for TRT7 bnding

### DIFF
--- a/tensorrt-sys/build.rs
+++ b/tensorrt-sys/build.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), ()> {
         cfg.define("TRT7", "");
         let bindings = builder()
             .clang_arg("-DTRT7")
-            .clang_arg("-x c++")
+            .clang_args(&["-x", "c++"])
             .header("trt-sys/tensorrt_api.h")
             .size_t_is_usize(true)
             .generate()?;


### PR DESCRIPTION
Hey,

I noticed the TRT7 binding config had a syntax error and couldn't build.
Sending here a small fix.
Picking up tensorrt work again, so I will check a windows build soon again