### PR TITLE
Cleanup bindings to IProfiler

### DIFF
--- a/tensorrt-sys/trt-sys/CMakeLists.txt
+++ b/tensorrt-sys/trt-sys/CMakeLists.txt
@@ -29,6 +29,7 @@ file(GLOB source_files
         "TRTHostMemory/*.cpp"
         "TRTLayer/*.cpp"
         "TRTTensor/*.cpp"
+        "TRTProfiler/*.cpp"
 )
 
 add_library(trt-sys STATIC ${source_files})

--- a/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
+++ b/tensorrt-sys/trt-sys/TRTContext/TRTContext.cpp
@@ -4,7 +4,7 @@
 #include <cuda_runtime.h>
 #include "NvInfer.h"
 #include "TRTContext.h"
-//#include "../TRTProfiler/TRTProfilerInternal.hpp"
+#include "../TRTProfiler/TRTProfilerInternal.hpp"
 //#include "../TRTUtils.hpp"
 
 //struct Context {
@@ -48,12 +48,10 @@ const char *context_get_name(nvinfer1::IExecutionContext *execution_context) {
     return execution_context->getName();
 }
 
-//void context_set_profiler(Context_t *context, Profiler_t *profiler) {
-//    auto concreteProfiler = new ConcreteProfiler(profiler);
-//    context->_concreteProfiler = concreteProfiler;
-//    context->internal_context->setProfiler(concreteProfiler);
-//}
-//
+void context_set_profiler(nvinfer1::IExecutionContext *context, CppProfiler* profiler) {
+    context->setProfiler(profiler);
+}
+
 //Profiler_t* context_get_profiler(Context_t *context) {
 //    auto concreteProfiler = dynamic_cast<ConcreteProfiler *>(context->internal_context->getProfiler());
 //    return concreteProfiler->getInternalProfiler();

--- a/tensorrt-sys/trt-sys/TRTContext/TRTContext.h
+++ b/tensorrt-sys/trt-sys/TRTContext/TRTContext.h
@@ -22,7 +22,7 @@ bool context_get_debug_sync(nvinfer1::IExecutionContext* execution_context);
 void context_set_name(nvinfer1::IExecutionContext* execution_context, const char *name);
 const char* context_get_name(nvinfer1::IExecutionContext *execution_context);
 
-//void context_set_profiler(Context_t execution_context, Profiler_t* profiler);
+void context_set_profiler(nvinfer1::IExecutionContext* execution_context, CppProfiler* profiler);
 //Profiler_t* context_get_profiler(Context_t *execution_context);
 
 void execute(nvinfer1::IExecutionContext* execution_context, void** buffers, int batch_size);

--- a/tensorrt-sys/trt-sys/TRTProfiler/TRTProfiler.cpp
+++ b/tensorrt-sys/trt-sys/TRTProfiler/TRTProfiler.cpp
@@ -1,0 +1,22 @@
+//
+// Created by mason on 12/16/20.
+//
+
+#include "TRTProfilerInternal.hpp"
+#include <iostream>
+
+CppProfiler* create_profiler(Profiler_t * rust_profiler) {
+    return new CppProfiler(rust_profiler);
+}
+
+void destroy_profiler(CppProfiler* profiler) {
+   delete profiler;
+}
+
+CppProfiler::~CppProfiler() {
+    (*profiler->destroy)(profiler, profiler->context);
+}
+
+void CppProfiler::reportLayerTime(const char *layerName, float ms) {
+    (*profiler->reportLayerTime)(profiler->context, layerName, ms);
+}

--- a/tensorrt-sys/trt-sys/TRTProfiler/TRTProfiler.h
+++ b/tensorrt-sys/trt-sys/TRTProfiler/TRTProfiler.h
@@ -5,15 +5,13 @@
 #ifndef LIBTRT_TRTPROFILER_H
 #define LIBTRT_TRTPROFILER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 struct Profiler;
 typedef struct Profiler Profiler_t;
+class CppProfiler;
 
-#ifdef __cplusplus
-};
-#endif
+CppProfiler* create_profiler(Profiler_t * rust_profiler);
+void destroy_profiler(CppProfiler* profiler);
+
 
 #endif //LIBTRT_TRTPROFILER_H

--- a/tensorrt-sys/trt-sys/TRTProfiler/TRTProfilerInternal.hpp
+++ b/tensorrt-sys/trt-sys/TRTProfiler/TRTProfilerInternal.hpp
@@ -10,23 +10,20 @@
 
 struct Profiler {
     void (*reportLayerTime)(void *context, const char *layerName, float ms);
-    void (*destroy)(void *self, void* context);
-    void* context;
+
+    void (*destroy)(void *self, void *context);
+
+    void *context;
 };
 
-class ConcreteProfiler : public nvinfer1::IProfiler {
+class CppProfiler : public nvinfer1::IProfiler {
 public:
-    explicit ConcreteProfiler(Profiler_t *_profiler) : profiler(_profiler) {}
+    explicit CppProfiler(Profiler_t *_profiler) : profiler(_profiler) {}
+    ~CppProfiler();
 
-    void reportLayerTime(const char* layerName, float ms) override {
-        (*profiler->reportLayerTime)(profiler->context, layerName, ms);
-    }
+    void reportLayerTime(const char *layerName, float ms) override;
 
-    void destroy() {
-        (*profiler->destroy)(profiler, profiler->context);
-    }
-
-    Profiler_t* getInternalProfiler() {
+    Profiler_t *getInternalProfiler() {
         return profiler;
     }
 

--- a/tensorrt/Cargo.toml
+++ b/tensorrt/Cargo.toml
@@ -19,9 +19,10 @@ trt-7 = ["tensorrt-sys/trt-7"]
 
 [dependencies]
 # Uncomment when working locally
-tensorrt-sys = { path = "../tensorrt-sys" }
-# tensorrt-sys = "0.3"
-tensorrt_rs_derive = { path = "../tensorrt_rs_derive" }
+#tensorrt-sys = { path = "../tensorrt-sys" }
+tensorrt-sys = { git = "https://github.com/mstallmo/tensorrt-rs", branch = "develop" }
+#tensorrt_rs_derive = { path = "../tensorrt_rs_derive" }
+tensorrt_rs_derive = { git = "https://github.com/mstallmo/tensorrt-rs", branch = "develop" }
 ndarray = "0.13"
 ndarray-image = "0.2"
 image = "0.23"

--- a/tensorrt/examples/mnist_uff/main.rs
+++ b/tensorrt/examples/mnist_uff/main.rs
@@ -7,6 +7,7 @@ use tensorrt_rs::context::ExecuteInput;
 use tensorrt_rs::data_size::GB;
 use tensorrt_rs::dims::DimsCHW;
 use tensorrt_rs::engine::Engine;
+use tensorrt_rs::profiler::{DefaultProfiler, Profiler};
 use tensorrt_rs::runtime::Logger;
 use tensorrt_rs::uff::{UffFile, UffInputOrder, UffParser};
 
@@ -32,8 +33,11 @@ fn main() {
     let uff_file = UffFile::new(Path::new("../assets/lenet5.uff")).unwrap();
     let engine = create_engine(&logger, uff_file);
 
+    let profiler = Profiler::new(DefaultProfiler::new());
+
     // Create execution context
     let context = engine.create_execution_context();
+    context.set_profiler(&profiler);
 
     // Load image from disk
     let input_image = image::open("../assets/images/0.pgm").unwrap().into_luma();

--- a/tensorrt/src/context.rs
+++ b/tensorrt/src/context.rs
@@ -1,5 +1,5 @@
 use crate::check_cuda;
-use crate::profiler::{IProfiler, ProfilerBinding};
+use crate::profiler::{IProfiler, Profiler};
 use anyhow::Error;
 use cuda_runtime_sys::{cudaFree, cudaMalloc, cudaMemcpy, cudaMemcpyKind};
 use ndarray;
@@ -12,7 +12,7 @@ use std::ptr;
 use std::vec::Vec;
 use tensorrt_sys::{
     context_get_debug_sync, context_get_name, context_set_debug_sync, context_set_name,
-    destroy_excecution_context, execute, nvinfer1_IExecutionContext, Profiler_t,
+    context_set_profiler, destroy_excecution_context, execute, nvinfer1_IExecutionContext,
 };
 
 pub enum ExecuteInput<'a, D: Dimension> {
@@ -106,12 +106,10 @@ impl Context {
         context_name.to_str().unwrap().to_string()
     }
 
-    // pub fn set_profiler<T: IProfiler>(&self, profiler: &mut T) {
-    //     let profiler_ptr =
-    //         Box::into_raw(Box::new(ProfilerBinding::new(profiler))) as *mut Profiler_t;
-    //     unsafe { context_set_profiler(self.internal_context, profiler_ptr) }
-    // }
-    //
+    pub fn set_profiler<P: IProfiler>(&self, profiler: &Profiler<P>) {
+        unsafe { context_set_profiler(self.internal_context, profiler.internal_profiler) }
+    }
+
     // pub fn get_profiler<T: IProfiler>(&self) -> &T {
     //     unsafe {
     //         let profiler_ptr =

--- a/tensorrt/src/utils.rs
+++ b/tensorrt/src/utils.rs
@@ -1,4 +1,4 @@
-pub mod cuda_utils {
+mod macros {
     #[macro_export]
     macro_rules! check_cuda {
         ($expression:expr) => {
@@ -9,6 +9,20 @@ pub mod cuda_utils {
                         std::ffi::CStr::from_ptr(cuda_runtime_sys::cudaGetErrorString(res));
                     return Err(anyhow::anyhow!("{}", error_message.to_str().unwrap()));
                 }
+            }
+        };
+    }
+
+    #[macro_export]
+    macro_rules! binding_func {
+        ($function_name:ident<$Trait:path>( $($arg_name:ident : $arg_ty:ty),*) ) => {
+
+            unsafe extern "C" fn $function_name<T: $Trait>(
+                context: *mut T,
+                $($arg_name: $arg_ty),*
+            ) {
+                let profiler_ref: &mut T = &mut *context;
+                profiler_ref.$function_name($($arg_name),*);
             }
         };
     }


### PR DESCRIPTION
Cleaned up some of the mechanics to binding to the IProfiler class. Exposed some more of the TensorRT C++ interface and reduced a little bit of indirection. 

Also I added in a macro for making bindings like this easier in the future. Hopefully this will make subclassing C++ from Rust with larger surface areas more straightforward and less repetitive. Specifically thinking about upcoming TensorRT plugin support in the library. 