### PR TITLE
Fix build error with re-generating tensorrt-sys dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - image: mstallmo/tensorrt-rs:0.5
     steps:
       - checkout
-      - run: cargo build --release
+      - run: cd tensorrt && cargo build --release
       - persist_to_workspace:
           root: /root
           paths:


### PR DESCRIPTION
Fixed build error in the build for TRT-7 when regenerating tensorrt-sys bindings.

It looks like with cargo workspaces that if we try to build from the root the tensorrt-sys bindings won't regenerate properly. To fix this we need to change directory into the tensorrt directory and then start the build from there rather than the root.